### PR TITLE
Feature/rotate part of model

### DIFF
--- a/ufit/base/src/operators/base/OT_rotate.py
+++ b/ufit/base/src/operators/base/OT_rotate.py
@@ -1,5 +1,5 @@
 from .....base.src.operators.core.OT_base import OTBase
-from .....base.src.operators.core.prepare import mirror, save_rotation
+from .....base.src.operators.core.prepare import mirror, save_rotation, rotate_part_of_model
 
 
 class OTMirror(OTBase):
@@ -16,6 +16,19 @@ class OTMirror(OTBase):
     def main_func(self, context):
         mirror(context)
 
+class OTRotatePartModel(OTBase):
+    @classmethod
+    def poll(cls, context):
+        # check if the uFit object is active
+        active_object = context.active_object
+        if active_object.select_get() \
+                and active_object.type == 'MESH' \
+                and active_object.mode == 'OBJECT' \
+                and active_object.name == 'uFit':
+            return True
+
+    def main_func(self, context):
+        rotate_part_of_model(context)
 
 class OTSaveRotation(OTBase):
     @classmethod

--- a/ufit/base/src/operators/core/prepare.py
+++ b/ufit/base/src/operators/core/prepare.py
@@ -231,6 +231,9 @@ def save_rotation(context):
     general.apply_transform(ufit_obj, use_location=True, use_rotation=True, use_scale=True)
 
 
+def rotate_part_of_model(context):
+    pass
+
 #################################
 # Circumferences
 #################################

--- a/ufit/base/src/properties/callbacks.py
+++ b/ufit/base/src/properties/callbacks.py
@@ -365,3 +365,40 @@ def enum_previews_for_assistance(self, context):
         return enum_previews
 
     return []
+
+
+def rotate_part_of_model(self, context):
+    ufit_obj = bpy.data.objects['uFit']
+
+    # Select object mode
+    general.activate_object(context, ufit_obj, mode='OBJECT')
+
+    if not self.ufit_rotate_part_of_model:
+        # Restore quad view
+        user_interface.set_quad_view(True)
+
+        # Permanently apply changes to the uFit object
+        bpy.ops.object.modifier_apply({"object": ufit_obj}, modifier='Lattice')
+
+        # Remove lattice
+        lattice_obj = bpy.data.objects["Lattice"]
+        general.activate_object(context, lattice_obj, mode='OBJECT')
+        bpy.ops.object.delete()
+
+        # Remove lattice modifier
+        general.remove_all_modifiers(ufit_obj)
+
+        # Activate the uFit object
+        general.activate_object(context, ufit_obj, mode='OBJECT')
+
+    else:
+        # Remove quad view
+        user_interface.set_quad_view(False)
+
+        # Add lattice modifier to the uFit object, only small changes allowed (strength=0.2)
+        lattice_obj = general.add_lattice_modifier(context, ufit_obj, strength=0.2)
+
+        # Activate built-in rotation tool
+        general.activate_object(context, lattice_obj, mode='EDIT')
+        bpy.ops.wm.tool_set_by_id(name="builtin.select_box")
+        user_interface.set_active_tool('builtin.rotate')

--- a/ufit/base/src/properties/properties.py
+++ b/ufit/base/src/properties/properties.py
@@ -65,6 +65,7 @@ ufit_scene_properties = [
     'ufit_sculpt_mode',
     'ufit_sculpt_tool',
     'ufit_vertex_color_all',
+    'ufit_rotate_part_of_model',
     'ufit_smooth_factor',
     'ufit_push_pull_circular',
     'ufit_extrude_amount',
@@ -230,6 +231,9 @@ def register():
                                                       update=callbacks.update_colors_enable)
     bpy.types.Scene.ufit_vertex_color_all = BoolProperty(name="Highlight Whole Object", default=False,
                                                          update=callbacks.update_vertex_color_all)
+    bpy.types.Scene.ufit_rotate_part_of_model = BoolProperty(name="Modify Scan (Rotation)", 
+                                                             default=False, 
+                                                             update=callbacks.rotate_part_of_model)
     bpy.types.Scene.ufit_smooth_factor = IntProperty(name="Factor", min=0, max=50, step=1, default=15)
     bpy.types.Scene.ufit_push_pull_circular = BoolProperty(name="Circular Push/Pull", default=True)
     bpy.types.Scene.ufit_extrude_amount = FloatProperty(name="Amount", min=0, max=100.0, step=50, default=3.5)
@@ -494,3 +498,5 @@ def unregister():
     # export
     del bpy.types.Scene.ufit_smooth_borders
     del bpy.types.Scene.ufit_show_inner_part
+
+    del bpy.types.Scene.ufit_rotate_part_of_model

--- a/ufit/base/src/ui/base/UI_rotate.py
+++ b/ufit/base/src/ui/base/UI_rotate.py
@@ -4,11 +4,21 @@ from .....base.src.ui.utils.general import get_standard_navbox
 
 
 class UIRotate(UFitPanel, bpy.types.Panel):
-    def draw_base(self, context, ot_save_rotation, ot_mirror=None):
+    def draw_base(self, context, ot_save_rotation, ot_mirror=None, ot_rotate_part_of_model=None):
         layout = self.layout
 
         if ot_mirror:
             row0 = layout.row()
             row0.operator(ot_mirror)
+
+
+        
+        if ot_rotate_part_of_model:
+            box0 = layout.box()
+            box0_row1 = box0.row()
+            box0_row1.prop(context.scene, "ufit_rotate_part_of_model", text="Enable Scan Adjustment")
+            box0_row2 = box0.row()
+            box0_row2.label(text="Uncheck the box to confirm.")
+
 
         get_standard_navbox(self.layout, "ufit_operators.prev_step", ot_save_rotation)

--- a/ufit/free_sculpting/src/free_sculpting_constants.py
+++ b/ufit/free_sculpting/src/free_sculpting_constants.py
@@ -203,6 +203,10 @@ fs_operator_consts = {
         'checkpoint': None,
         'next_step': None
     },
+    'rotate_part_of_model': {
+        'checkpoint': None,
+        'next_step': None
+    },
     'rotate': {
         'checkpoint': {
             'name': 'rotate',

--- a/ufit/free_sculpting/src/workflow/ST_50_rotate/OT_rotate_scan.py
+++ b/ufit/free_sculpting/src/workflow/ST_50_rotate/OT_rotate_scan.py
@@ -1,5 +1,5 @@
 from ..OT_Base_FS import OTBaseFS
-from .....base.src.operators.base.OT_rotate import OTMirror, OTSaveRotation
+from .....base.src.operators.base.OT_rotate import OTMirror, OTSaveRotation, OTRotatePartModel
 
 
 class OTMirrorFS(OTBaseFS, OTMirror):
@@ -12,6 +12,16 @@ class OTMirrorFS(OTBaseFS, OTMirror):
         return self.execute_base(context,
                                  operator_name='mirror')
 
+class OTRotatePartModelFS(OTBaseFS, OTRotatePartModel):
+    """Tooltip"""
+    bl_idname = "fs_operators.rotate_part_of_model"
+    bl_label = "Modify Scan"
+    bl_options = {"REGISTER", "UNDO"}
+
+    def execute(self, context):
+        return self.execute_base(context,
+                                 operator_name='rotate_part_of_model')
+
 
 class OTSaveRotationFS(OTBaseFS, OTSaveRotation):
     """Tooltip"""
@@ -22,5 +32,3 @@ class OTSaveRotationFS(OTBaseFS, OTSaveRotation):
     def execute(self, context):
         return self.execute_base(context,
                                  operator_name='rotate')
-
-

--- a/ufit/free_sculpting/src/workflow/ST_50_rotate/UI_rotate_scan.py
+++ b/ufit/free_sculpting/src/workflow/ST_50_rotate/UI_rotate_scan.py
@@ -9,7 +9,8 @@ class UIRotateFS(UIRotate):
     def draw(self, context):
         self.draw_base(context,
                        ot_save_rotation="fs_operators.save_rotation",
-                       ot_mirror="fs_operators.mirror")
+                       ot_mirror="fs_operators.mirror",
+                       ot_rotate_part_of_model="fs_operators.rotate_part_of_model")
 
     @classmethod
     def poll(cls, context):

--- a/ufit/free_sculpting/src/workflow/operators.py
+++ b/ufit/free_sculpting/src/workflow/operators.py
@@ -9,7 +9,7 @@ from .ST_40_verify_clean_up.OT_verify_clean_up import (
     OTDeleteNonManifoldFS,
     OTApproveCleanUpFS,
 )
-from .ST_50_rotate.OT_rotate_scan import OTMirrorFS, OTSaveRotationFS
+from .ST_50_rotate.OT_rotate_scan import OTMirrorFS, OTSaveRotationFS, OTRotatePartModelFS
 from .ST_70_push_pull_smooth.OT_push_pull_smooth import (
     OTPushPullRegionFS,
     OTSmoothRegionFS,
@@ -40,6 +40,7 @@ def register():
     bpy.utils.register_class(OTDeleteNonManifoldFS)
     bpy.utils.register_class(OTApproveCleanUpFS)
     bpy.utils.register_class(OTMirrorFS)
+    bpy.utils.register_class(OTRotatePartModelFS)
     bpy.utils.register_class(OTSaveRotationFS)
     bpy.utils.register_class(OTSmoothRegionFS)
     bpy.utils.register_class(OTPushPullRegionFS)
@@ -71,6 +72,7 @@ def unregister():
     bpy.utils.unregister_class(OTDeleteNonManifoldFS)
     bpy.utils.unregister_class(OTApproveCleanUpFS)
     bpy.utils.unregister_class(OTMirrorFS)
+    bpy.utils.unregister_class(OTRotatePartModelFS)
     bpy.utils.unregister_class(OTSaveRotationFS)
     bpy.utils.unregister_class(OTSmoothRegionFS)
     bpy.utils.unregister_class(OTPushPullRegionFS)


### PR DESCRIPTION
Task: Add option in the rotation step to twist/rotate part of the model.
Solution found: Create a lattice adjusted to the size of the uFit object and use a lattice modifier to rotate part of the model.

Notes on the choices made:
- Only small rotations are allowed as this modifier does not preserve volumes, it can be adjusted with the `strength` parameter. 
- The size of the lattice grid is controlled with the `grid_factor` parameter, it can be adjusted if necessary.
- The option is activated by checking the box in the panel, and changes are validated by unchecking the box. You cannot proceed to the next step until the changes have been validated. 